### PR TITLE
Updated example of file naming version control

### DIFF
--- a/_episodes/01-git-github.md
+++ b/_episodes/01-git-github.md
@@ -38,18 +38,18 @@ How do you record the history of your projects?
 
 ### Good - Informatively named files
 ```
-   2013-10-14_manuscriptFish.doc
-   2013-10-30_manuscriptFish.doc
-   2013-11-05_manusctiptFish_intitialRyanEdits.doc
-   2013-11-10_manuscriptFish.doc
-   2013-11-11_manuscriptFish.doc
-   2013-11-15_manuscriptFish.doc
-   2013-11-30_manuscriptFish.doc
-   2013-12-01_manuscriptFish.doc
-   2013-12-02_manuscriptFish_PNASsubmitted.doc
-   2014-01-03_manuscriptFish_PLOSsubmitted.doc
-   2014-02-15_manuscriptFish_PLOSrevision.doc
-   2014-03-14_manuscriptFish_PLOSpublished.doc
+   manuscriptFish_2013-10-14.doc
+   manuscriptFish_2013-10-30.doc
+   manuscriptFish_2013-11-05_intitialRyanEdits.doc
+   manuscriptFish_2013-11-10.doc
+   manuscriptFish_2013-11-11.doc
+   manuscriptFish_2013-11-15.doc
+   manuscriptFish_2013-11-30.doc
+   manuscriptFish_2013-12-01.doc
+   manuscriptFish_2013-12-02_PNASsubmitted.doc
+   manuscriptFish_2014-01-03_PLOSsubmitted.doc
+   manuscriptFish_2014-02-15_PLOSrevision.doc
+   manuscriptFish_2014-03-14_PLOSpublished.doc
 ```
 
 ## Better - Saving everything together at once


### PR DESCRIPTION
Hi!

I'm proposing a change to improve the version control example that uses file naming so that the example file names all have the same root ("manuscriptFish"). Having the same root/beginning of the file name shows that the files are related, with the appended date information showing what the major difference is between the versions. When you put date first in the file name, it makes it seem like the date is the most important thing about this set of files and then that they all happen to be on the same topic. Basically, content information should go first with version information second so that the files sort properly if mixed in with other files.

That said, I love the use of ISO 8601 on the date formatting in these file names. What a great example of how using YYYY-MM-DD makes your files sort chronologically!

Thanks,
Kristin